### PR TITLE
Update nodemon configuration to use npx for ts-node execution

### DIFF
--- a/nodemon.json
+++ b/nodemon.json
@@ -1,5 +1,5 @@
 {
 	"watch": ["./src"],
 	"ext": ".js,.ts",
-	"exec": "ts-node server.ts"
+	"exec": "npx ts-node server.ts"
 }


### PR DESCRIPTION
This pull request includes a small change to the `nodemon.json` file. The change updates the execution command to use `npx` for running `ts-node` on `server.ts`.

* [`nodemon.json`](diffhunk://#diff-1d7174a5b72c6ecace2f5d30dc09a4d6cbba8da4ee95063cba0645c0f27066c6L4-R4): Modified the `exec` command to use `npx ts-node server.ts` instead of `ts-node server.ts`.